### PR TITLE
Add optional debug logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set (headers
 set (sources
     src/Container.cpp
     src/Connection.cpp
+    src/Logger.hpp
     src/Session.cpp
     src/Sender.cpp
     src/Receiver.cpp
@@ -36,7 +37,13 @@ find_package(QpidProton REQUIRED)
 target_include_directories(${TARGET} PRIVATE ${QPID_PROTON_INCLUDE_DIR})
 
 add_definitions(-DPROTON_IMPERATIVE_EXPORTS)
-target_include_directories(${TARGET} PUBLIC "${CMAKE_SOURCE_DIR}/include")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -DENABLE_DEBUG_MODE -O0")
+
+target_include_directories(${TARGET} 
+   PRIVATE ${QPID_PROTON_INCLUDE_DIR} "${CMAKE_SOURCE_DIR}/src"
+   PUBLIC "${CMAKE_SOURCE_DIR}/include"
+)
+
 target_link_libraries(${TARGET} ${GTEST_BOTH_LIBRARIES} ${QPID_PROTON_CPP_LIBRARIES})
 
 add_subdirectory(test)

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -1,11 +1,18 @@
 #include <proton/imperative/Connection.hpp>
 #include <proton/imperative/Session.hpp>
 
-#include <iostream>
+#include <Logger.hpp>
+
+#include <proton/connection_options.hpp>
+#include <proton/container.hpp>
 
 using namespace proton;
 
 static std::string containerCloseMsg("Container explicitly closed");
+
+namespace {
+   Log debug_log;
+}
 
 Connection::Connection(container& c, const std::string& url, connection_options conn_opts, CloseRegistry* containerCloseRegistry)
    : m_connectionHandler(new ConnectionHandler(containerCloseRegistry))
@@ -62,7 +69,7 @@ Connection::ConnectionHandler::ConnectionHandler(CloseRegistry* containerCloseHa
 
 void Connection::ConnectionHandler::on_connection_open(connection& conn)
 {
-   std::cout << "client on_connection_open" << std::endl;
+   debug_log << "client on_connection_open" << std::endl;
    m_connection = conn;
    m_work = &m_connection.work_queue();
    m_manager.handlePnOpen();
@@ -71,33 +78,33 @@ void Connection::ConnectionHandler::on_connection_open(connection& conn)
 void Connection::ConnectionHandler::on_connection_close(connection&)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_connection_close" << std::endl;
+   debug_log << "client on_connection_close" << std::endl;
 }
 
 void Connection::ConnectionHandler::on_connection_error(connection& conn)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_connection_error: " << conn.error().what() << std::endl;
+   debug_log << "client on_connection_error: " << conn.error().what() << std::endl;
    m_manager.handlePnError(conn.error().what());
 }
 
 void Connection::ConnectionHandler::on_transport_open(transport&)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_transport_open" << std::endl;
+   debug_log << "client on_transport_open" << std::endl;
 }
 
 void Connection::ConnectionHandler::on_transport_close(transport&)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_transport_close" << std::endl;
+   debug_log << "client on_transport_close" << std::endl;
    m_manager.handlePnClose();
 }
 
 void Connection::ConnectionHandler::on_transport_error(transport& t)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_transport_error: " << t.error().what() << std::endl;
+   debug_log << "client on_transport_error: " << t.error().what() << std::endl;
 
    if (t.error().description().find(containerCloseMsg) != std::string::npos)
    {
@@ -112,7 +119,7 @@ void Connection::ConnectionHandler::on_transport_error(transport& t)
 void Connection::ConnectionHandler::releasePnMemberObjects(const std::string&)
 {
    // Reseting pn objects for thread safety
-   std::cout << "---Connection releasePnMemberObjects before" << std::endl;
+   debug_log << "---Connection releasePnMemberObjects before" << std::endl;
    m_connection = connection();
-   std::cout << "---Connection releasePnMemberObjects" << std::endl;
+   debug_log << "---Connection releasePnMemberObjects" << std::endl;
 }

--- a/src/Delivery.cpp
+++ b/src/Delivery.cpp
@@ -1,7 +1,5 @@
 #include <proton/imperative/Delivery.hpp>
 
-#include <iostream>
-
 using namespace proton;
 
 void Delivery::accept()

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -1,0 +1,31 @@
+#ifndef PROTON_IMPERATIVE_LOGGER_HPP
+#define PROTON_IMPERATIVE_LOGGER_HPP
+
+#include <iostream>
+
+namespace {
+
+class Log {
+public:
+   template <typename T>
+   const Log& operator<< (T&& log) const
+   {
+   #ifdef ENABLE_DEBUG_MODE
+      std::cout << std::forward<T>(log);
+   #endif
+      return *this;
+   }
+};
+
+
+const Log& operator<< (const Log& log, std::ostream& (stream) (std::ostream&)) 
+{
+#ifdef ENABLE_DEBUG_MODE
+   std::cout << stream;
+#endif
+   return log;
+}
+
+}
+
+#endif

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -1,9 +1,13 @@
 #include <proton/imperative/Receiver.hpp>
 #include <proton/imperative/Delivery.hpp>
 
-#include <iostream>
+#include <Logger.hpp>
 
 using namespace proton;
+
+namespace {
+   Log debug_log;
+}
 
 Receiver::Receiver(work_queue* work, session& sess, const std::string& address, receiver_options rec_opts, CloseRegistry* sessionCloseRegistry)
    : m_receiverHandler(new ReceiverHandler(work, sessionCloseRegistry))
@@ -72,29 +76,29 @@ std::future<Delivery> Receiver::ReceiverHandler::receive()
 
 void Receiver::ReceiverHandler::on_receiver_open(receiver& rec)
 {
-   std::cout << "client on_receiver_open" << std::endl;
+   debug_log << "client on_receiver_open" << std::endl;
    m_manager.handlePnOpen();
 }
 
 void Receiver::ReceiverHandler::on_receiver_close(receiver&)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_receiver_close" << std::endl;
-   std::cout << "pointer : " << &m_unclosedDeliveries << "  size" << m_unclosedDeliveries.size() << std::endl;
+   debug_log << "client on_receiver_close" << std::endl;
+   debug_log << "pointer : " << &m_unclosedDeliveries << "  size" << m_unclosedDeliveries.size() << std::endl;
    m_manager.handlePnClose();
 }
 
 void Receiver::ReceiverHandler::on_receiver_error(receiver& rec)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_receiver_error" << std::endl;
+   debug_log << "client on_receiver_error" << std::endl;
    m_manager.handlePnError(rec.error().what());
 }
 
 void Receiver::ReceiverHandler::on_message(delivery& d, message& m)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_message" << std::endl;
+   debug_log << "client on_message" << std::endl;
    {
       std::lock_guard<std::mutex> l1(m_listLock);
       m_unclosedDeliveries.emplace_back(d);

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -1,8 +1,12 @@
 #include <proton/imperative/Sender.hpp>
 
-#include <iostream>
+#include <Logger.hpp>
 
 using namespace proton;
+
+namespace {
+   Log debug_log;
+}
 
 Sender::Sender(work_queue* work, session& sess, const std::string& address, sender_options send_opts, CloseRegistry* sessionCloseRegistry)
    :m_senderHandler(new SenderHandler(work, sessionCloseRegistry))
@@ -74,34 +78,34 @@ std::future<void> Sender::SenderHandler::send(const message& mess)
 
 void Sender::SenderHandler::on_sender_open(sender& sen)
 {
-   std::cout << "client on_sender_open" << std::endl;
+   debug_log << "client on_sender_open" << std::endl;
    m_manager.handlePnOpen();
 }
 
 void Sender::SenderHandler::on_sender_close(sender&)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_sender_close" << std::endl;
+   debug_log << "client on_sender_close" << std::endl;
    m_manager.handlePnClose();
 }
 
 void Sender::SenderHandler::on_sender_error(sender& sen)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_sender_error" << std::endl;
+   debug_log << "client on_sender_error" << std::endl;
    m_manager.handlePnError(sen.error().what());
 }
 
 void Sender::SenderHandler::on_tracker_accept(tracker& track)
 {
-   std::cout << "client on_tracker_accept" << std::endl;
+   debug_log << "client on_tracker_accept" << std::endl;
    auto promise = removeTrackerFromMapIfFoundElseThow(track);
    promise->set_value();
 }
 
 void Sender::SenderHandler::on_tracker_reject(tracker& track)
 {
-   std::cout << "client on_tracker_settle" << std::endl;
+   debug_log << "client on_tracker_settle" << std::endl;
    auto promise = removeTrackerFromMapIfFoundElseThow(track);
    auto except = std::make_exception_ptr(std::runtime_error("message was rejected by peer"));
    promise->set_exception(except);
@@ -109,7 +113,7 @@ void Sender::SenderHandler::on_tracker_reject(tracker& track)
 
 void Sender::SenderHandler::on_tracker_release(tracker& track)
 {
-   std::cout << "client on_tracker_settle" << std::endl;
+   debug_log << "client on_tracker_settle" << std::endl;
    auto promise = removeTrackerFromMapIfFoundElseThow(track);
    auto except = std::make_exception_ptr(std::runtime_error("message was released by peer"));
    promise->set_exception(except);

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -2,9 +2,13 @@
 #include <proton/imperative/Sender.hpp>
 #include <proton/imperative/Receiver.hpp>
 
-#include <iostream>
+#include <Logger.hpp>
 
 using namespace proton;
+
+namespace {
+   Log debug_log;
+}
 
 Session::Session(connection& con, work_queue* work, session_options sess_opts, CloseRegistry* connectionCloseRegistry)
    : m_sessionHandler(new SessionHandler(work, connectionCloseRegistry))
@@ -72,21 +76,21 @@ Session::SessionHandler::SessionHandler(work_queue* w, CloseRegistry* connection
 
 void Session::SessionHandler::on_session_open(session& sess)
 {
-   std::cout << "client on_session_open" << std::endl;
+   debug_log << "client on_session_open" << std::endl;
    m_manager.handlePnOpen();
 }
 
 void Session::SessionHandler::on_session_close(session&)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_session_close" << std::endl;
+   debug_log << "client on_session_close" << std::endl;
    m_manager.handlePnClose();
 }
 
 void Session::SessionHandler::on_session_error(session& sess)
 {
    std::lock_guard<std::mutex> lock(m_manager.m_mutex);
-   std::cout << "client on_session_error" << std::endl;
+   debug_log << "client on_session_error" << std::endl;
    m_manager.handlePnError(sess.error().what());
 }
 


### PR DESCRIPTION
for now, this is very basic to be able to toggle on/off the logging.
to toggle off, either #undef the flag, or remove it from cmake and re-configure.
by default, with release it is switched off.
in the future, this should be more dynamic, perhaps it can be tackled in a separate logger story.
